### PR TITLE
Fixing infinite recursion issue with OddEvenMerge when input size is …

### DIFF
--- a/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
@@ -124,7 +124,17 @@ public class CollectionsSortingTests {
           Boolean[] left41 = ByteAndBitConverter.toBoolean("02");
           Boolean[] left42 = ByteAndBitConverter.toBoolean("05");
 
-          Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary> app =
+          Boolean[] left51 = ByteAndBitConverter.toBoolean("11");
+          Boolean[] left52 = ByteAndBitConverter.toBoolean("10");
+          Boolean[] left61 = ByteAndBitConverter.toBoolean("13");
+          Boolean[] left62 = ByteAndBitConverter.toBoolean("17");
+          Boolean[] left71 = ByteAndBitConverter.toBoolean("19");
+          Boolean[] left72 = ByteAndBitConverter.toBoolean("16");
+          Boolean[] left81 = ByteAndBitConverter.toBoolean("12");
+          Boolean[] left82 = ByteAndBitConverter.toBoolean("15");
+
+          // Test sorting without using the mergePresortedHalves flag
+          Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary> appSort =
               new Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary>() {
 
             @Override
@@ -144,11 +154,27 @@ public class CollectionsSortingTests {
                     Arrays.asList(left31).stream().map(builder::known).collect(Collectors.toList());
                 List<DRes<SBool>> l32 =
                     Arrays.asList(left32).stream().map(builder::known).collect(Collectors.toList());
-
                 List<DRes<SBool>> l41 =
                     Arrays.asList(left41).stream().map(builder::known).collect(Collectors.toList());
                 List<DRes<SBool>> l42 =
                     Arrays.asList(left42).stream().map(builder::known).collect(Collectors.toList());
+
+                List<DRes<SBool>> l51 =
+                    Arrays.asList(left51).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l52 =
+                    Arrays.asList(left52).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l61 =
+                    Arrays.asList(left61).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l62 =
+                    Arrays.asList(left62).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l71 =
+                    Arrays.asList(left71).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l72 =
+                    Arrays.asList(left72).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l81 =
+                    Arrays.asList(left81).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l82 =
+                    Arrays.asList(left82).stream().map(builder::known).collect(Collectors.toList());
 
                 List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> unSorted = new ArrayList<>();
 
@@ -156,6 +182,11 @@ public class CollectionsSortingTests {
                 unSorted.add(new Pair<>(l21, l22));
                 unSorted.add(new Pair<>(l31, l32));
                 unSorted.add(new Pair<>(l41, l42));
+                unSorted.add(new Pair<>(l51, l52));
+                unSorted.add(new Pair<>(l61, l62));
+                unSorted.add(new Pair<>(l71, l72));
+                unSorted.add(new Pair<>(l81, l82));
+
 
                 DRes<List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>>> sorted =
                     new OddEvenMerge(unSorted).buildComputation(seq);
@@ -188,16 +219,132 @@ public class CollectionsSortingTests {
 
           };
 
-          List<Pair<List<Boolean>, List<Boolean>>> results = runApplication(app);
+          List<Pair<List<Boolean>, List<Boolean>>> resultsSort = runApplication(appSort);
 
-          Assert.assertEquals(Arrays.asList(left21), results.get(0).getFirst());
-          Assert.assertEquals(Arrays.asList(left22), results.get(0).getSecond());
-          Assert.assertEquals(Arrays.asList(left41), results.get(1).getFirst());
-          Assert.assertEquals(Arrays.asList(left42), results.get(1).getSecond());
-          Assert.assertEquals(Arrays.asList(left11), results.get(2).getFirst());
-          Assert.assertEquals(Arrays.asList(left12), results.get(2).getSecond());
-          Assert.assertEquals(Arrays.asList(left31), results.get(3).getFirst());
-          Assert.assertEquals(Arrays.asList(left32), results.get(3).getSecond());
+          Assert.assertEquals(Arrays.asList(left71), resultsSort.get(0).getFirst());
+          Assert.assertEquals(Arrays.asList(left72), resultsSort.get(0).getSecond());
+          Assert.assertEquals(Arrays.asList(left61), resultsSort.get(1).getFirst());
+          Assert.assertEquals(Arrays.asList(left62), resultsSort.get(1).getSecond());
+          Assert.assertEquals(Arrays.asList(left81), resultsSort.get(2).getFirst());
+          Assert.assertEquals(Arrays.asList(left82), resultsSort.get(2).getSecond());
+          Assert.assertEquals(Arrays.asList(left51), resultsSort.get(3).getFirst());
+          Assert.assertEquals(Arrays.asList(left52), resultsSort.get(3).getSecond());
+
+          Assert.assertEquals(Arrays.asList(left21), resultsSort.get(4).getFirst());
+          Assert.assertEquals(Arrays.asList(left22), resultsSort.get(4).getSecond());
+          Assert.assertEquals(Arrays.asList(left41), resultsSort.get(5).getFirst());
+          Assert.assertEquals(Arrays.asList(left42), resultsSort.get(5).getSecond());
+          Assert.assertEquals(Arrays.asList(left11), resultsSort.get(6).getFirst());
+          Assert.assertEquals(Arrays.asList(left12), resultsSort.get(6).getSecond());
+          Assert.assertEquals(Arrays.asList(left31), resultsSort.get(7).getFirst());
+          Assert.assertEquals(Arrays.asList(left32), resultsSort.get(7).getSecond());
+
+
+          // Test using the mergePresortedHalves flag
+          Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary> appMergeOnly =
+              new Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary>() {
+            @Override
+            public DRes<List<Pair<List<Boolean>, List<Boolean>>>> buildComputation(
+                    ProtocolBuilderBinary producer) {
+              return producer.seq(seq -> {
+                Binary builder = seq.binary();
+                List<DRes<SBool>> l11 =
+                        Arrays.asList(left11).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l12 =
+                        Arrays.asList(left12).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l21 =
+                        Arrays.asList(left21).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l22 =
+                        Arrays.asList(left22).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l31 =
+                        Arrays.asList(left31).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l32 =
+                        Arrays.asList(left32).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l41 =
+                        Arrays.asList(left41).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l42 =
+                        Arrays.asList(left42).stream().map(builder::known).collect(Collectors.toList());
+
+                List<DRes<SBool>> l51 =
+                        Arrays.asList(left51).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l52 =
+                        Arrays.asList(left52).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l61 =
+                        Arrays.asList(left61).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l62 =
+                        Arrays.asList(left62).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l71 =
+                        Arrays.asList(left71).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l72 =
+                        Arrays.asList(left72).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l81 =
+                        Arrays.asList(left81).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l82 =
+                        Arrays.asList(left82).stream().map(builder::known).collect(Collectors.toList());
+
+                List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> unSorted = new ArrayList<>();
+                
+                // Keep in mind that the first n / 2 keys need to be sorted, as do the second n / 2 keys.
+                // With the way comparisons work currently, we need the two halves to be sorted in descending order.
+                unSorted.add(new Pair<>(l21, l22));
+                unSorted.add(new Pair<>(l41, l42));
+                unSorted.add(new Pair<>(l11, l12));
+                unSorted.add(new Pair<>(l31, l32));
+                unSorted.add(new Pair<>(l71, l72));
+                unSorted.add(new Pair<>(l61, l62));
+                unSorted.add(new Pair<>(l81, l82));
+                unSorted.add(new Pair<>(l51, l52));
+
+                DRes<List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>>> sorted =
+                        new OddEvenMerge(unSorted, true).buildComputation(seq);
+                return sorted;
+              }).seq((seq, sorted) -> {
+                Binary builder = seq.binary();
+                List<Pair<List<DRes<Boolean>>, List<DRes<Boolean>>>> opened = new ArrayList<>();
+                for (Pair<List<DRes<SBool>>, List<DRes<SBool>>> p : sorted) {
+                  List<DRes<Boolean>> oKeys = new ArrayList<>();
+                  for (DRes<SBool> key : p.getFirst()) {
+                    oKeys.add(builder.open(key));
+                  }
+                  List<DRes<Boolean>> oValues = new ArrayList<>();
+                  for (DRes<SBool> value : p.getSecond()) {
+                    oValues.add(builder.open(value));
+                  }
+                  opened.add(new Pair<>(oKeys, oValues));
+                }
+                return () -> opened;
+              }).seq((seq, opened) -> {
+                return () -> opened.stream().map((p) -> {
+                  List<Boolean> key =
+                          p.getFirst().stream().map(DRes::out).collect(Collectors.toList());
+                  List<Boolean> value =
+                          p.getSecond().stream().map(DRes::out).collect(Collectors.toList());
+                  return new Pair<>(key, value);
+                }).collect(Collectors.toList());
+              });
+            }
+
+          };
+
+          List<Pair<List<Boolean>, List<Boolean>>> resultsMergeOnly = runApplication(appMergeOnly);
+
+          Assert.assertEquals(Arrays.asList(left71), resultsMergeOnly.get(0).getFirst());
+          Assert.assertEquals(Arrays.asList(left72), resultsMergeOnly.get(0).getSecond());
+          Assert.assertEquals(Arrays.asList(left61), resultsMergeOnly.get(1).getFirst());
+          Assert.assertEquals(Arrays.asList(left62), resultsMergeOnly.get(1).getSecond());
+          Assert.assertEquals(Arrays.asList(left81), resultsMergeOnly.get(2).getFirst());
+          Assert.assertEquals(Arrays.asList(left82), resultsMergeOnly.get(2).getSecond());
+          Assert.assertEquals(Arrays.asList(left51), resultsMergeOnly.get(3).getFirst());
+          Assert.assertEquals(Arrays.asList(left52), resultsMergeOnly.get(3).getSecond());
+
+          Assert.assertEquals(Arrays.asList(left21), resultsMergeOnly.get(4).getFirst());
+          Assert.assertEquals(Arrays.asList(left22), resultsMergeOnly.get(4).getSecond());
+          Assert.assertEquals(Arrays.asList(left41), resultsMergeOnly.get(5).getFirst());
+          Assert.assertEquals(Arrays.asList(left42), resultsMergeOnly.get(5).getSecond());
+          Assert.assertEquals(Arrays.asList(left11), resultsMergeOnly.get(6).getFirst());
+          Assert.assertEquals(Arrays.asList(left12), resultsMergeOnly.get(6).getSecond());
+          Assert.assertEquals(Arrays.asList(left31), resultsMergeOnly.get(7).getFirst());
+          Assert.assertEquals(Arrays.asList(left32), resultsMergeOnly.get(7).getSecond());
         }
       };
     }


### PR DESCRIPTION
…greater than four.

Modifying TestOddEvenMerge to test sorting for input of size eight.

Adding a constructor for OddEvenMerge with the `mergePresortedHalves` flag to allow merging
a list with individually sorted halves into a fully sorted list.

Adding a test in TestOddEvenMerge for the `mergePresortedHalves` flag.